### PR TITLE
Cleanup: Reduce Soyuz size

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,17 +1,16 @@
 version: 2.1
-
 workflows:
-  build-and-push:
+  build:
     jobs:
-       - build-n-push:
-           context: org-global
+    - build-all:
+        filters:
+          branches:
+            ignore:
+              - master
+
 jobs:
- build-n-push:
+ build-all:
    machine: true
    steps:
      - checkout
-     - run: make build
-     - run: make build-latest
-     - run: docker login ${DOCKER_REGISTRY} -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
-     - run: make push
-     - run: make push-latest
+     - run: make build-all

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,6 +7,14 @@ workflows:
           branches:
             ignore:
               - master
+  latest:
+    jobs:
+    - build-n-push-latest:
+        context: org-global
+        filters:
+          branches:
+            only:
+              - master
 
 jobs:
  build-all:
@@ -14,3 +22,10 @@ jobs:
    steps:
      - checkout
      - run: make build-all
+ build-n-push-latest:
+   machine: true
+   steps:
+     - checkout
+     - run: make latest-build
+     - run: docker login ${DOCKER_REGISTRY} -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+     - run: make latest-push

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,6 +15,14 @@ workflows:
           branches:
             only:
               - master
+  release:
+    jobs:
+    - build-n-push-release:
+        filters:
+          tags:
+            only: /^v.*/
+          branches:
+            ignore: /.*/
 
 jobs:
  build-all:
@@ -29,3 +37,10 @@ jobs:
      - run: make latest-build
      - run: docker login ${DOCKER_REGISTRY} -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
      - run: make latest-push
+ build-n-push-release:
+   machine: true
+   steps:
+     - checkout
+     - run: make release-build
+     - run: docker login ${DOCKER_REGISTRY} -u ${DOCKER_USERNAME} -p ${DOCKER_PASSWORD}
+     - run: make release-push

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,7 @@
-FROM alpine:3.7
+FROM hashicorp/terraform:0.12.29 as terraform
+
+
+FROM debian:stable-slim
 
 ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get update \
@@ -12,6 +15,7 @@ RUN apt-get update \
   && apt-get autoremove -y --purge \
   && rm -rf /var/lib/apt/lists/*
 
+COPY --from=terraform /bin/terraform /usr/bin
 
 RUN apk add --update \
   git openssh-client \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM hashicorp/terraform:0.12.29 as terraform
 
+FROM golang:1.14.6-buster as go
+
+RUN go get -u github.com/dmitry-at-hyla/liche
 
 FROM debian:stable-slim
 
@@ -8,34 +11,21 @@ RUN apt-get update \
   &&  apt-get install -y --no-install-recommends \
   git make openssh-client \
   default-mysql-client \
-  python3-minimal\
+  python3-minimal ruby \
   awscli \
-  ruby \
   && apt-get clean autoclean \
   && apt-get autoremove -y --purge \
   && rm -rf /var/lib/apt/lists/*
 
 COPY --from=terraform /bin/terraform /usr/bin
 
-RUN apk add --update \
-  git openssh-client \
-  make build-base bash \
-  mysql-client \
-  busybox-extras \
-  go \
-  ruby python python-dev py-pip \
-  && pip install --upgrade pip \
-  && pip install awscli==$AWSCLI_VERSION --upgrade \
-  && apk --purge -v del py-pip \
-  && rm -rf /var/cache/apk/* \
-  && rm -rf $HOME/.cache
+ENV GO_BIN /go/bin
+ENV PATH "$GO_BIN:$PATH"
 
-RUN go get -u github.com/dmitry-at-hyla/liche
+COPY --from=go /go/bin $GO_BIN
 
 ENV BIN_3SCALE /opt/3scale/bin
-
 ENV PATH "$BIN_3SCALE:$PATH"
 
 ADD bin/ $BIN_3SCALE
-
 RUN chmod -R 0755 $BIN_3SCALE

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,17 @@
 FROM alpine:3.7
 
-ENV AWSCLI_VERSION 1.18.4
+ENV DEBIAN_FRONTEND noninteractive
+RUN apt-get update \
+  &&  apt-get install -y --no-install-recommends \
+  git make openssh-client \
+  default-mysql-client \
+  python3-minimal\
+  awscli \
+  ruby \
+  && apt-get clean autoclean \
+  && apt-get autoremove -y --purge \
+  && rm -rf /var/lib/apt/lists/*
+
 
 RUN apk add --update \
   git openssh-client \

--- a/Dockerfile-ci
+++ b/Dockerfile-ci
@@ -1,5 +1,9 @@
 FROM hashicorp/terraform:0.12.29 as terraform
-FROM golang:1.14.6-buster as go
+
+FROM golang:1.14.6-alpine as go
+
+# install git, required by `go get`
+RUN apk add --update git
 
 RUN go get -u github.com/dmitry-at-hyla/liche
 

--- a/Dockerfile-ci
+++ b/Dockerfile-ci
@@ -1,0 +1,27 @@
+FROM hashicorp/terraform:0.12.29 as terraform
+FROM golang:1.14.6-buster as go
+
+RUN go get -u github.com/dmitry-at-hyla/liche
+
+FROM alpine:3.7
+
+ENV AWSCLI_VERSION 1.18.4
+
+RUN apk add --update \
+  git make bash \
+  && apk --purge -v del py-pip \
+  && rm -rf /var/cache/apk/* \
+  && rm -rf $HOME/.cache
+
+COPY --from=terraform /bin/terraform /usr/bin
+
+ENV GO_BIN /go/bin
+ENV PATH "$GO_BIN:$PATH"
+
+COPY --from=go /go/bin $GO_BIN
+
+ENV BIN_3SCALE /opt/3scale/bin
+ENV PATH "$BIN_3SCALE:$PATH"
+
+ADD bin/ $BIN_3SCALE
+RUN chmod -R 0755 $BIN_3SCALE

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 .PHONY: help
 
-TAG	?= 0.0.3
+TAG	?= build
 CI_TAG ?= ci
 HUB	?= quay.io/3scale
 IMAGE	?= quay.io/3scale/soyuz

--- a/Makefile
+++ b/Makefile
@@ -11,9 +11,13 @@ help:
 		| awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' \
 		| egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | sort
 
-build-all: build build-latest build-$(CI_TAG) build-$(CI_TAG)-latest
+release-build: build push-$(CI_TAG)
 
-push-all: push push-latest push-$(CI_TAG) push-$(CI_TAG)-latest
+release-push: push push-$(CI_TAG)
+
+latest-build: build-latest build-$(CI_TAG)-latest
+
+latest-push: push-latest push-$(CI_TAG)-latest
 
 build:
 	docker build -t $(IMAGE):$(TAG) -f Dockerfile .

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 
 .PHONY: help
 
-TAG	?= 0.0.2
+CI_TAG ?= ci
 HUB	?= quay.io/3scale
 IMAGE	?= quay.io/3scale/soyuz
 
@@ -20,4 +20,16 @@ build-latest: build
 	docker tag $(IMAGE):$(TAG) $(IMAGE):latest
 
 push-latest: build-latest
+	docker push $(IMAGE):$(TAG)
+
+build-$(CI_TAG):
+	docker build -t $(IMAGE):$(TAG)-$(CI_TAG) -f Dockerfile-$(CI_TAG) .
+
+push-$(CI_TAG):
+	docker push $(IMAGE):$(TAG)-$(CI_TAG)
+
+build-$(CI_TAG)-latest: build
+	docker tag $(IMAGE):$(TAG)-$(CI_TAG) $(IMAGE):latest
+
+push-$(CI_TAG)-latest: build-latest
 	docker push $(IMAGE):$(TAG)

--- a/Makefile
+++ b/Makefile
@@ -10,6 +10,10 @@ help:
 		| awk -v RS= -F: '/^# File/,/^# Finished Make data base/ {if ($$1 !~ "^[#.]") {print $$1}}' \
 		| egrep -v -e '^[^[:alnum:]]' -e '^$@$$' | sort
 
+build-all: build build-latest build-$(CI_TAG) build-$(CI_TAG)-latest
+
+push-all: push push-latest push-$(CI_TAG) push-$(CI_TAG)-latest
+
 build:
 	docker build -t $(IMAGE):$(TAG) -f Dockerfile .
 

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 
 .PHONY: help
 
+TAG	?= 0.0.3
 CI_TAG ?= ci
 HUB	?= quay.io/3scale
 IMAGE	?= quay.io/3scale/soyuz

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ latest-build: build-latest build-$(CI_TAG)-latest
 
 latest-push: push-latest push-$(CI_TAG)-latest
 
+build-all: build build-ci
+
 build:
 	docker build -t $(IMAGE):$(TAG) -f Dockerfile .
 


### PR DESCRIPTION
Reduces the size of Soyuz image about a 50% and adds an even smaller `ci` image with only the toolchain required by our current pipelines.

```
REPOSITORY                                    TAG                 IMAGE ID            CREATED             SIZE
quay.io/3scale/soyuz                          build-ci            728aa3eaa1c0        3 minutes ago       103MB
quay.io/3scale/soyuz                          build               23c25cc574a0        13 minutes ago      380MB
quay.io/3scale/soyuz                          0.0.2               5a3f55f0bdaa        15 hours ago        699MB
```